### PR TITLE
Refactor LoadSBOM to LoadSBOMFromFile and LoadSBOMFromReader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,5 +19,5 @@ jobs:
         run: go get .
       - name: Build
         run: go build -v ./...
-      - name: Test with the Go CLI
-        run: go test
+      - name: Run tests
+        run: go test -v ./... 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
-name: Go
-on: [push]
+name: CI
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: Go
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+      - name: Install dependencies
+        run: go get .
+      - name: Build
+        run: go build -v ./...
+      - name: Test with the Go CLI
+        run: go test

--- a/cmd/files.go
+++ b/cmd/files.go
@@ -22,7 +22,7 @@ func filesCmd() *cobra.Command {
 Example:
 	obom files -f ./examples/SPDXJSONExample-v2.3.spdx.json`,
 		Run: func(cmd *cobra.Command, args []string) {
-			sbom, _, err := obom.LoadSBOM(opts.filename)
+			sbom, _, err := obom.LoadSBOMFromFile(opts.filename)
 			if err != nil {
 				fmt.Println("Error loading SBOM:", err)
 				os.Exit(1)

--- a/cmd/packages.go
+++ b/cmd/packages.go
@@ -19,7 +19,7 @@ func packagesCmd() *cobra.Command {
 		Short: "List packages the SBOM",
 		Long:  `List packages the SBOM that have external refs`,
 		Run: func(cmd *cobra.Command, args []string) {
-			sbom, _, err := obom.LoadSBOM(opts.filename)
+			sbom, _, err := obom.LoadSBOMFromFile(opts.filename)
 			if err != nil {
 				fmt.Println("Error loading SBOM:", err)
 				os.Exit(1)

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -54,7 +54,7 @@ Example - Push an SPDX SBOM to a registry with annotations and credentials
 				os.Exit(1)
 			}
 
-			sbom, desc, err := obom.LoadSBOM(opts.filename)
+			sbom, desc, err := obom.LoadSBOMFromFile(opts.filename)
 			if err != nil {
 				fmt.Println("Error loading SBOM:", err)
 				os.Exit(1)

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -20,7 +20,7 @@ func showCmd() *cobra.Command {
 		Short: "Show summay of the spdx",
 		Long:  `Show the SPDX summary fields`,
 		Run: func(cmd *cobra.Command, args []string) {
-			sbom, desc, err := obom.LoadSBOM(opts.filename)
+			sbom, desc, err := obom.LoadSBOMFromFile(opts.filename)
 			if err != nil {
 				fmt.Println("Error loading SBOM:", err)
 				os.Exit(1)

--- a/pkg/sbom.go
+++ b/pkg/sbom.go
@@ -1,7 +1,6 @@
 package obom
 
 import (
-	"fmt"
 	"os"
 
 	"crypto/sha256"
@@ -25,21 +24,31 @@ const (
 	OCI_ANNOTATION_ANNOTATION_DATE    = "org.spdx.annotation_date"
 )
 
-// LoadSBOM loads an SPDX file into memory
-func LoadSBOM(filename string) (*v2_3.Document, *oci.Descriptor, error) {
+func LoadSBOMFromFile(filename string) (*v2_3.Document, *oci.Descriptor, error) {
 	file, err := os.Open(filename)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to open file: %w", err)
+		return nil, nil, err
 	}
 	defer file.Close()
 
-	doc, err := json.Read(file)
+	fileSize, err := getFileSize(file)
 	if err != nil {
-		fmt.Printf("Error while parsing SPDX file %s: %v\n", filename, err)
 		return nil, nil, err
 	}
 
-	desc, err := GetFileDescriptor(filename)
+	return LoadSBOMFromReader(file, fileSize)
+}
+
+// LoadSBOM loads an SPDX file into memory
+func LoadSBOMFromReader(reader io.ReadCloser, size int64) (*v2_3.Document, *oci.Descriptor, error) {
+	defer reader.Close()
+
+	doc, err := json.Read(reader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	desc, err := getFileDescriptor(reader, size)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -47,19 +56,12 @@ func LoadSBOM(filename string) (*v2_3.Document, *oci.Descriptor, error) {
 	return doc, desc, nil
 }
 
-func GetFileDescriptor(filename string) (*oci.Descriptor, error) {
-	// Open the file
-	file, err := os.Open(filename)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
+func getFileDescriptor(reader io.ReadCloser, size int64) (*oci.Descriptor, error) {
 	// Create a new SHA256 hasher
 	hasher := sha256.New()
 
 	// Copy the file's contents into the hasher
-	if _, err := io.Copy(hasher, file); err != nil {
+	if _, err := io.Copy(hasher, reader); err != nil {
 		return nil, err
 	}
 
@@ -71,19 +73,23 @@ func GetFileDescriptor(filename string) (*oci.Descriptor, error) {
 
 	d := digest.NewDigestFromHex("sha256", hashString)
 
-	fInfo, err := file.Stat()
-	if err != nil {
-		return nil, err
-	}
-
-	fileSize := fInfo.Size()
 	desc := &oci.Descriptor{
 		MediaType: MEDIATYPE_SPDX,
 		Digest:    d,
-		Size:      fileSize,
+		Size:      size,
 	}
 
 	return desc, nil
+}
+
+func getFileSize(file *os.File) (int64, error) {
+	// Get the file size
+	fileInfo, err := file.Stat()
+	if err != nil {
+		return 0, err
+	}
+
+	return fileInfo.Size(), nil
 }
 
 // GetAnnotations returns the annotations from the SBOM

--- a/pkg/sbom.go
+++ b/pkg/sbom.go
@@ -24,6 +24,9 @@ const (
 	OCI_ANNOTATION_ANNOTATION_DATE    = "org.spdx.annotation_date"
 )
 
+// LoadSBOMFromFile opens a file given by filename, reads its contents, and loads it into an SPDX document.
+// It also calculates the file size and generates an OCI descriptor for the file.
+// It returns the loaded SPDX document, the OCI descriptor, and any error encountered.
 func LoadSBOMFromFile(filename string) (*v2_3.Document, *oci.Descriptor, error) {
 	file, err := os.Open(filename)
 	if err != nil {
@@ -39,7 +42,10 @@ func LoadSBOMFromFile(filename string) (*v2_3.Document, *oci.Descriptor, error) 
 	return LoadSBOMFromReader(file, fileSize)
 }
 
-// LoadSBOM loads an SPDX file into memory
+// LoadSBOMFromReader reads an SPDX document from an io.ReadCloser, generates an OCI descriptor for the document,
+// and returns the loaded SPDX document and the OCI descriptor.
+// The size parameter is the size of the document in bytes.
+// If an error occurs during reading the document or generating the descriptor, the error will be returned.
 func LoadSBOMFromReader(reader io.ReadCloser, size int64) (*v2_3.Document, *oci.Descriptor, error) {
 	defer reader.Close()
 

--- a/pkg/sbom_test.go
+++ b/pkg/sbom_test.go
@@ -34,7 +34,6 @@ func TestLoadSBOMFromReader(t *testing.T) {
 	}
 
 	// Check that the returned doc and desc have the expected values
-	// You'll need to replace these checks with checks that are appropriate for your code
 	if doc.DocumentName != "SPDX-Example" {
 		t.Errorf("expected document name to be 'SPDX-Example', got: %v", doc.DocumentName)
 	}
@@ -57,7 +56,6 @@ func TestLoadSBOMFromFile(t *testing.T) {
 	}
 
 	// Check that the returned doc and desc have the expected values
-	// You'll need to replace these checks with checks that are appropriate for your code
 	if doc.DocumentName != "SPDX-Tools-v2.0" {
 		t.Errorf("expected document name to be 'SPDX-Tools-v2.0', got: %v", doc.DocumentName)
 	}

--- a/pkg/sbom_test.go
+++ b/pkg/sbom_test.go
@@ -1,0 +1,67 @@
+package obom
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestLoadSBOMFromReader(t *testing.T) {
+	// Create a test SPDX JSON string
+	spdx := `{
+			"SPDXID": "SPDXRef-DOCUMENT",
+			"spdxVersion": "SPDX-2.3",
+			"name" : "SPDX-Example",
+			"creationInfo": {
+					"created": "2020-07-23T18:30:22Z",
+					"creators": ["Tool: SPDX-Java-Tools-v2.1.20", "Organization: Source Auditor Inc."],
+					"licenseListVersion": "3.6"
+			}
+	}`
+
+	// Calculate the size of the SPDX string in bytes
+	size := int64(len([]byte(spdx)))
+
+	// Create a test reader with the SPDX JSON data
+	reader := io.NopCloser(strings.NewReader(spdx))
+
+	// Call the function with the test reader
+	doc, desc, err := LoadSBOMFromReader(reader, size)
+
+	// Check that there was no error
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	// Check that the returned doc and desc have the expected values
+	// You'll need to replace these checks with checks that are appropriate for your code
+	if doc.DocumentName != "SPDX-Example" {
+		t.Errorf("expected document name to be 'SPDX-Example', got: %v", doc.DocumentName)
+	}
+	if desc.Size != size {
+		t.Errorf("expected desc.Size to be %v, got: %v", size, desc.Size)
+	}
+}
+
+func TestLoadSBOMFromFile(t *testing.T) {
+	// Define the path to the test file and its size
+	filePath := "../examples/SPDXJSONExample-v2.3.spdx.json"
+	size := int64(21342)
+
+	// Call the function with the test file path
+	doc, desc, err := LoadSBOMFromFile(filePath)
+
+	// Check that there was no error
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	// Check that the returned doc and desc have the expected values
+	// You'll need to replace these checks with checks that are appropriate for your code
+	if doc.DocumentName != "SPDX-Tools-v2.0" {
+		t.Errorf("expected document name to be 'SPDX-Tools-v2.0', got: %v", doc.DocumentName)
+	}
+	if desc.Size != size {
+		t.Errorf("expected desc.Size to be %v, got: %v", size, desc.Size)
+	}
+}


### PR DESCRIPTION
## Summary
Added a new function `LoadSBOMFromReader` that reads an SBOM from a `io.ReadCloser`. `LoadSBOM` is renamed to `LoadSBOMFromFile` and now uses the new function for its implementation.

## Motivation
An SBOM may need to be read from an arbitrary source such as a download from a network storage. `LoadSBOMFromReader` allows a user to read an SBOM directly into memory without having to write a file to disk.

### Notes
- Added a few simple tests as there were no tests yet. Will be adding more tests in subsequent PRs
- Added a simple GitHub Action for CI. After this is merged, we can require this as a check