### PR TITLE
Refactor PushFiles to PushSBOM

### DIFF
--- a/cmd/files.go
+++ b/cmd/files.go
@@ -22,7 +22,7 @@ func filesCmd() *cobra.Command {
 Example:
 	obom files -f ./examples/SPDXJSONExample-v2.3.spdx.json`,
 		Run: func(cmd *cobra.Command, args []string) {
-			sbom, _, err := obom.LoadSBOMFromFile(opts.filename)
+			sbom, _, _, err := obom.LoadSBOMFromFile(opts.filename)
 			if err != nil {
 				fmt.Println("Error loading SBOM:", err)
 				os.Exit(1)

--- a/cmd/packages.go
+++ b/cmd/packages.go
@@ -19,7 +19,7 @@ func packagesCmd() *cobra.Command {
 		Short: "List packages the SBOM",
 		Long:  `List packages the SBOM that have external refs`,
 		Run: func(cmd *cobra.Command, args []string) {
-			sbom, _, err := obom.LoadSBOMFromFile(opts.filename)
+			sbom, _, _, err := obom.LoadSBOMFromFile(opts.filename)
 			if err != nil {
 				fmt.Println("Error loading SBOM:", err)
 				os.Exit(1)

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -78,7 +78,7 @@ Example - Push an SPDX SBOM to a registry with annotations and credentials
 				annotations[k] = v
 			}
 
-			err = obom.PushFiles(opts.filename, opts.reference, annotations, opts.username, opts.password)
+			err = obom.PushSBOM(sbom, desc, opts.reference, annotations, opts.username, opts.password)
 			if err != nil {
 				fmt.Println("Error pushing SBOM:", err)
 				os.Exit(1)

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -8,9 +8,11 @@ import (
 
 	"github.com/Azure/obom/internal/print"
 	obom "github.com/Azure/obom/pkg"
+	credentials "github.com/oras-project/oras-credentials-go"
 	"github.com/spf13/cobra"
 
 	"oras.land/oras-go/v2/registry"
+	"oras.land/oras-go/v2/registry/remote/auth"
 )
 
 type pushOpts struct {
@@ -48,13 +50,13 @@ Example - Push an SPDX SBOM to a registry with annotations and credentials
 			opts.reference = args[0]
 
 			// validate if reference is valid
-			_, err := registry.ParseReference(opts.reference)
+			ref, err := registry.ParseReference(opts.reference)
 			if err != nil {
 				fmt.Println("Error parsing reference:", err)
 				os.Exit(1)
 			}
 
-			sbom, desc, err := obom.LoadSBOMFromFile(opts.filename)
+			sbom, desc, bytes, err := obom.LoadSBOMFromFile(opts.filename)
 			if err != nil {
 				fmt.Println("Error loading SBOM:", err)
 				os.Exit(1)
@@ -78,7 +80,14 @@ Example - Push an SPDX SBOM to a registry with annotations and credentials
 				annotations[k] = v
 			}
 
-			err = obom.PushSBOM(sbom, desc, opts.reference, annotations, opts.username, opts.password)
+			// get the credentials resolver
+			resolver, err := getCredentialsResolver(ref.Registry, opts.username, opts.password)
+			if err != nil {
+				fmt.Println("Error getting credentials resolver:", err)
+				os.Exit(1)
+			}
+
+			err = obom.PushSBOM(sbom, desc, bytes, opts.reference, annotations, resolver)
 			if err != nil {
 				fmt.Println("Error pushing SBOM:", err)
 				os.Exit(1)
@@ -113,4 +122,20 @@ func parseAnnotationFlags(flags []string) (map[string]string, error) {
 		manifestAnnotations[key] = val
 	}
 	return manifestAnnotations, nil
+}
+
+func getCredentialsResolver(registry string, username string, password string) (obom.CredentialsResolver, error) {
+	if len(username) != 0 && len(password) != 0 {
+		return auth.StaticCredential(registry, auth.Credential{
+			Username: username,
+			Password: password,
+		}), nil
+	} else {
+		storeOpts := credentials.StoreOptions{}
+		store, err := credentials.NewStoreFromDocker(storeOpts)
+		if err != nil {
+			return nil, err
+		}
+		return credentials.Credential(store), nil
+	}
 }

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -20,7 +20,7 @@ func showCmd() *cobra.Command {
 		Short: "Show summay of the spdx",
 		Long:  `Show the SPDX summary fields`,
 		Run: func(cmd *cobra.Command, args []string) {
-			sbom, desc, err := obom.LoadSBOMFromFile(opts.filename)
+			sbom, desc, _, err := obom.LoadSBOMFromFile(opts.filename)
 			if err != nil {
 				fmt.Println("Error loading SBOM:", err)
 				os.Exit(1)

--- a/pkg/oras.go
+++ b/pkg/oras.go
@@ -7,11 +7,9 @@ import (
 	"strings"
 
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-	credentials "github.com/oras-project/oras-credentials-go"
 
 	"github.com/spdx/tools-golang/spdx/v2/v2_3"
 	"oras.land/oras-go/v2"
-	"oras.land/oras-go/v2/content/file"
 	"oras.land/oras-go/v2/content/memory"
 
 	// "oras.land/oras-go/v2/content/reader"
@@ -26,101 +24,6 @@ const (
 )
 
 type CredentialsResolver = func(context.Context, string) (auth.Credential, error)
-
-// PushFiles pushes the SPDX SBOM file to the registry
-func PushFiles(filename string, reference string, spdx_annotations map[string]string, username string, password string) error {
-
-	// 0. Create a file store
-	fs, err := file.New(".")
-	if err != nil {
-		return err
-	}
-	defer fs.Close()
-	ctx := context.Background()
-
-	// Add files to a file store
-	mediaType := MEDIATYPE_SPDX
-	fileNames := []string{filename}
-	fileDescriptors := make([]v1.Descriptor, 0, len(fileNames))
-	for _, name := range fileNames {
-		fileDescriptor, err := fs.Add(ctx, name, mediaType, "")
-		if err != nil {
-			return err
-		}
-		fileDescriptors = append(fileDescriptors, fileDescriptor)
-		fmt.Printf("Adding %s: %s\n", name, fileDescriptor.Digest)
-	}
-
-	annotations := make(map[string]string)
-	for k, v := range spdx_annotations {
-		annotations[k] = v
-	}
-
-	//Pack the files and tag the packed manifest
-	artifactType := MEDIATYPE_SPDX
-	manifestDescriptor, err := oras.Pack(ctx, fs, artifactType, fileDescriptors, oras.PackOptions{
-		PackImageManifest:   true,
-		ManifestAnnotations: annotations,
-	})
-	if err != nil {
-		return err
-	}
-
-	// Use the latest tag isf no tag is specified
-	tag := "latest"
-	ref, err := registry.ParseReference(reference)
-	if err != nil {
-		return err
-	}
-
-	if ref.Reference != "" {
-		tag = ref.Reference
-	}
-	fmt.Printf("Pushing %s/%s:%s %s\n", ref.Registry, ref.Repository, tag, manifestDescriptor.Digest)
-	if err = fs.Tag(ctx, manifestDescriptor, tag); err != nil {
-		return err
-	}
-
-	//Connect to a remote repository
-	repo, err := remote.NewRepository(reference)
-	if err != nil {
-		panic(err)
-	}
-
-	// Check if registry has is localhost or starts with localhost:
-	reg := repo.Reference.Registry
-	if strings.HasPrefix(reg, "localhost:") {
-		repo.PlainHTTP = true
-	}
-
-	// Prepare the auth client for the registry
-	client := &auth.Client{
-		Client: retry.DefaultClient,
-		Cache:  auth.DefaultCache,
-	}
-
-	if len(username) != 0 && len(password) != 0 {
-		client.Credential = auth.StaticCredential(reg, auth.Credential{
-			Username: username,
-			Password: password,
-		})
-	} else {
-		storeOpts := credentials.StoreOptions{}
-		store, err := credentials.NewStoreFromDocker(storeOpts)
-		if err != nil {
-			return err
-		}
-
-		client.Credential = credentials.Credential(store)
-	}
-
-	client.SetUserAgent(APPLICATION_USERAGENT)
-	repo.Client = client
-
-	//Copy from the file store to the remote repository
-	_, err = oras.Copy(ctx, fs, tag, repo, tag, oras.DefaultCopyOptions)
-	return err
-}
 
 // PushSBOM pushes the SPDX SBOM bytes to the registry
 func PushSBOM(sbomDoc *v2_3.Document, sbomDescriptor *v1.Descriptor, sbomBytes []byte, reference string, spdx_annotations map[string]string, credsResolver CredentialsResolver) error {
@@ -141,7 +44,7 @@ func PushSBOM(sbomDoc *v2_3.Document, sbomDescriptor *v1.Descriptor, sbomBytes [
 		annotations[k] = v
 	}
 
-	//Pack the files and tag the packed manifest
+	// Pack the files and tag the packed manifest
 	artifactType := MEDIATYPE_SPDX
 	descriptors := []v1.Descriptor{*sbomDescriptor}
 	manifestDescriptor, err := oras.Pack(ctx, mem, artifactType, descriptors, oras.PackOptions{

--- a/pkg/oras.go
+++ b/pkg/oras.go
@@ -12,7 +12,6 @@ import (
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content/memory"
 
-	// "oras.land/oras-go/v2/content/reader"
 	"oras.land/oras-go/v2/registry"
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"

--- a/pkg/oras.go
+++ b/pkg/oras.go
@@ -67,7 +67,7 @@ func PushSBOM(sbomDoc *v2_3.Document, sbomDescriptor *v1.Descriptor, sbomBytes [
 	if ref.Reference != "" {
 		tag = ref.Reference
 	}
-	fmt.Printf("Pushing %s/%s:%s %s\n", ref.Registry, ref.Repository, tag, manifestDescriptor.Digest)
+
 	if err = mem.Tag(ctx, manifestDescriptor, tag); err != nil {
 		return err
 	}
@@ -75,7 +75,7 @@ func PushSBOM(sbomDoc *v2_3.Document, sbomDescriptor *v1.Descriptor, sbomBytes [
 	// Connect to a remote repository
 	repo, err := remote.NewRepository(reference)
 	if err != nil {
-		panic(fmt.Errorf("error connecting to remote repository: %w", err))
+		return fmt.Errorf("error connecting to remote repository: %w", err)
 	}
 
 	// Check if registry has is localhost or starts with localhost:

--- a/pkg/sbom.go
+++ b/pkg/sbom.go
@@ -48,20 +48,32 @@ func LoadSBOMFromFile(filename string) (*v2_3.Document, *oci.Descriptor, []byte,
 // If an error occurs during reading the document or generating the descriptor, the error will be returned.
 func LoadSBOMFromReader(reader io.ReadCloser, size int64) (*v2_3.Document, *oci.Descriptor, []byte, error) {
 	defer reader.Close()
-	var buf = &bytes.Buffer{}
-	clonedReader := io.TeeReader(reader, buf)
-	doc, err := json.Read(clonedReader)
+
+	// Read all the bytes from the reader into a slice
+	sbomBytes, err := readAllBytes(reader)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
-	sbomReader := bytes.NewReader(buf.Bytes())
+	// Create a bytes.Reader from the slice
+	sbomReader := bytes.NewReader(sbomBytes)
+
+	// Read the SPDX document from the reader
+	doc, err := json.Read(sbomReader)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Reset the reader for the next read
+	sbomReader.Reset(sbomBytes)
+
+	// Generate the OCI descriptor for the SPDX document
 	desc, err := getFileDescriptor(sbomReader, size)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
-	return doc, desc, buf.Bytes(), nil
+	return doc, desc, sbomBytes, nil
 }
 
 func getFileDescriptor(reader io.Reader, size int64) (*oci.Descriptor, error) {
@@ -98,6 +110,15 @@ func getFileSize(file *os.File) (int64, error) {
 	}
 
 	return fileInfo.Size(), nil
+}
+
+func readAllBytes(reader io.Reader) ([]byte, error) {
+	var buf bytes.Buffer
+	_, err := io.Copy(&buf, reader)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 // GetAnnotations returns the annotations from the SBOM

--- a/pkg/sbom_test.go
+++ b/pkg/sbom_test.go
@@ -26,7 +26,7 @@ func TestLoadSBOMFromReader(t *testing.T) {
 	reader := io.NopCloser(strings.NewReader(spdx))
 
 	// Call the function with the test reader
-	doc, desc, err := LoadSBOMFromReader(reader, size)
+	doc, desc, _, err := LoadSBOMFromReader(reader, size)
 
 	// Check that there was no error
 	if err != nil {
@@ -48,7 +48,7 @@ func TestLoadSBOMFromFile(t *testing.T) {
 	size := int64(21342)
 
 	// Call the function with the test file path
-	doc, desc, err := LoadSBOMFromFile(filePath)
+	doc, desc, _, err := LoadSBOMFromFile(filePath)
 
 	// Check that there was no error
 	if err != nil {

--- a/pkg/sbom_test.go
+++ b/pkg/sbom_test.go
@@ -1,6 +1,7 @@
 package obom
 
 import (
+	"bytes"
 	"io"
 	"strings"
 	"testing"
@@ -20,13 +21,14 @@ func TestLoadSBOMFromReader(t *testing.T) {
 	}`
 
 	// Calculate the size of the SPDX string in bytes
-	size := int64(len([]byte(spdx)))
+	expectedBytes := []byte(spdx)
+	size := int64(len(expectedBytes))
 
 	// Create a test reader with the SPDX JSON data
 	reader := io.NopCloser(strings.NewReader(spdx))
 
 	// Call the function with the test reader
-	doc, desc, _, err := LoadSBOMFromReader(reader, size)
+	doc, desc, sbomBytes, err := LoadSBOMFromReader(reader, size)
 
 	// Check that there was no error
 	if err != nil {
@@ -39,6 +41,10 @@ func TestLoadSBOMFromReader(t *testing.T) {
 	}
 	if desc.Size != size {
 		t.Errorf("expected desc.Size to be %v, got: %v", size, desc.Size)
+	}
+	// Check if the byte arrays are equal
+	if !bytes.Equal(sbomBytes, expectedBytes) {
+		t.Errorf("expected sbomBytes to be %v, got: %v", expectedBytes, sbomBytes)
 	}
 }
 


### PR DESCRIPTION
## Background
Currently, `obom` is structured around reading SPDX documents from files on disk. However, in order to support use cases where the SPDX document may be read in from a different source, such as a network download, we need to support reading the SPDX document into memory and push that in-memory representation to an OCI registry.

## Summary
The `PushFiles` function was refactored to `PushSBOM` by not requiring a file path to be passed in. Instead, `PushSBOM` now accepts the SBOM byte slice along with the SPDX document struct and the OCI descriptor struct. The `LoadSBOMFrom` functions now also return a byte slice. This is makes it easier for a user to not repeatedly read from a `Reader` to get the bytes just to pass in. 

Initially, the approach was to just marshal the SPDX document struct back to a string and get the bytes from there, but this actually modifies the original formatting of the SPDX document. In the event that an SPDX document is signed, we cannot modify the contents of the SPDX when it is pushed to the OCI registry. This is the motivation for passing around the byte slice.

For a user who is reading a SPDX document from a `Reader` and pushing to a OCI registry, they would first call `LoadSBOMFromReader` and take the returned values and pass them into `PushSBOM`.

## Additional changes
`PushSBOM` now requires a credential resolver function as an argument which is how [`oras-go` handles authentication](https://github.com/oras-project/oras-go/blob/bbe92af00542d87ab6feeef1be1be4c6dffcf121/registry/remote/auth/client.go#L82). The `obom` CLI arguments are unchanged - the logic of determining which credential to use (username/password vs docker) is now hoisted out of `pkg`. This change now enables a user of the package to determine their authentication strategy outside of the options available to the CLI.