### PR TITLE
Add SBOM summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ $ obom show -f ./examples/SPDXJSONExample-v2.3.spdx.json
 Document Name:         SPDX-Tools-v2.0
 DataLicense:           CC0-1.0
 Document Namespace:    http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301
-SPDX Version:          SPDX-2.3
+SPDX Version:          SPDX-2.3 # NOTE This is the default version for all spdx you have to comment out line 76 
+                                # from go\pkg\mod\github.com\spdx\tools-golang@v0.5.0\spdx\v2\v2_3\document.go
+                                # in order to pull the correct version from the actual SPDX JSON
 Creation Date:         2010-01-29T18:30:22Z
 Creators:              LicenseFind-1.0
                        ExampleCodeInspect ()

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -20,6 +20,7 @@ type pushOpts struct {
 	reference           string
 	username            string
 	password            string
+	pushSummary         bool
 	ManifestAnnotations []string
 }
 
@@ -87,7 +88,7 @@ Example - Push an SPDX SBOM to a registry with annotations and credentials
 				os.Exit(1)
 			}
 
-			err = obom.PushSBOM(sbom, desc, bytes, opts.reference, annotations, resolver)
+			err = obom.PushSBOM(sbom, desc, bytes, opts.reference, annotations, resolver, opts.pushSummary)
 			if err != nil {
 				fmt.Println("Error pushing SBOM:", err)
 				os.Exit(1)
@@ -102,6 +103,7 @@ Example - Push an SPDX SBOM to a registry with annotations and credentials
 
 	pushCmd.Flags().StringVarP(&opts.username, "username", "u", "", "Username for the registry")
 	pushCmd.Flags().StringVarP(&opts.password, "password", "p", "", "Password for the registry")
+	pushCmd.Flags().BoolVarP(&opts.pushSummary, "pushSummary", "s", false, "Push summary blob to the registry")
 
 	// Add positional argument called reference to pushCmd
 	pushCmd.Args = cobra.ExactArgs(1)

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc4
 	github.com/oras-project/oras-credentials-go v0.1.0
+	github.com/package-url/packageurl-go v0.1.1
 	github.com/spdx/tools-golang v0.5.0
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/viper v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -149,6 +149,8 @@ github.com/opencontainers/image-spec v1.1.0-rc4 h1:oOxKUJWnFC4YGHCCMNql1x4YaDfYB
 github.com/opencontainers/image-spec v1.1.0-rc4/go.mod h1:X4pATf0uXsnn3g5aiGIsVnJBR4mxhKzfwmvK/B2NTm8=
 github.com/oras-project/oras-credentials-go v0.1.0 h1:XaGxQD4qK8jxOGSNqrPlh/lKlVSL/PBH89WraYjyZkE=
 github.com/oras-project/oras-credentials-go v0.1.0/go.mod h1:wxHUtRSULM8DVTGgc8DFtIKXDZr2JLD/48WYPqvKoJs=
+github.com/package-url/packageurl-go v0.1.1 h1:KTRE0bK3sKbFKAk3yy63DpeskU7Cvs/x/Da5l+RtzyU=
+github.com/package-url/packageurl-go v0.1.1/go.mod h1:uQd4a7Rh3ZsVg5j0lNyAfyxIeGde9yrlhjF78GzeW0c=
 github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvIwycIU=
 github.com/pelletier/go-toml/v2 v2.0.6/go.mod h1:eumQOmlWiOPt5WriQQqoM5y18pDHwha2N+QD+EUNTek=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/internal/print/print.go
+++ b/internal/print/print.go
@@ -26,7 +26,6 @@ func PrintCreatorInfo(doc *v2_3.Document) {
 func PrintSBOMSummary(doc *v2_3.Document, desc *oci.Descriptor) {
 	fmt.Println(strings.Repeat("=", 80))
 	fmt.Printf("Document Name:         %s\n", doc.DocumentName)
-	fmt.Printf("DataLicense:           %s\n", doc.DataLicense)
 	fmt.Printf("Document Namespace:    %s\n", doc.DocumentNamespace)
 	fmt.Printf("SPDX Version:          %s\n", doc.SPDXVersion)
 	fmt.Printf("Creation Date:         %s\n", doc.CreationInfo.Created)

--- a/pkg/sbom.go
+++ b/pkg/sbom.go
@@ -1,7 +1,10 @@
 package obom
 
 import (
+	"fmt"
 	"os"
+	"strconv"
+	"strings"
 
 	"crypto/sha256"
 	"encoding/hex"
@@ -20,6 +23,10 @@ const (
 	OCI_ANNOTATION_DOCUMENT_NAMESPACE = "org.spdx.namespace"
 	OCI_ANNOTATION_SPDX_VERSION       = "org.spdx.version"
 	OCI_ANNOTATION_CREATION_DATE      = "org.spdx.created"
+	OCI_ANNOTATION_CREATORS           = "org.spdx.creator"
+	OCI_ANNOTATION_PACKAGES           = "org.spdx.packages"
+	OCI_ANNOTATION_PACKAGE_COUNT      = "org.spdx.package_count"
+	OCI_ANNOTATION_FILES              = "org.spdx.files"
 	OCI_ANNOTATION_ANNOTATOR          = "org.spdx.annotator"
 	OCI_ANNOTATION_ANNOTATION_DATE    = "org.spdx.annotation_date"
 )
@@ -100,6 +107,15 @@ func getFileSize(file *os.File) (int64, error) {
 
 // GetAnnotations returns the annotations from the SBOM
 func GetAnnotations(sbom *v2_3.Document) (map[string]string, error) {
+        var creatorstrings []string
+	for _, creator := range sbom.CreationInfo.Creators {
+		creatorstrings = append(creatorstrings, fmt.Sprint(creator.Creator))
+	}
+
+	var packages []string
+	for _, pkg := range sbom.Packages {
+		packages = append(packages, fmt.Sprint(pkg.PackageName)+":"+fmt.Sprint(pkg.PackageVersion)+":"+fmt.Sprint(pkg.PackageLicenseDeclared))
+	}
 	annotations := make(map[string]string)
 
 	annotations[OCI_ANNOTATION_DOCUMENT_NAME] = sbom.DocumentName
@@ -107,6 +123,10 @@ func GetAnnotations(sbom *v2_3.Document) (map[string]string, error) {
 	annotations[OCI_ANNOTATION_DOCUMENT_NAMESPACE] = sbom.DocumentNamespace
 	annotations[OCI_ANNOTATION_SPDX_VERSION] = sbom.SPDXVersion
 	annotations[OCI_ANNOTATION_CREATION_DATE] = sbom.CreationInfo.Created
+	annotations[OCI_ANNOTATION_CREATORS] = strings.Join(creatorstrings, ", ")
+	annotations[OCI_ANNOTATION_PACKAGE_COUNT] = strconv.Itoa(len(sbom.Packages))
+	annotations[OCI_ANNOTATION_PACKAGES] = strings.Join(packages, ", ")
+	annotations[OCI_ANNOTATION_FILES] = strconv.Itoa(len(sbom.Files))
 
 	return annotations, nil
 }


### PR DESCRIPTION
# Description
Add an SBOM "summary" to the SBOM OCI artifact as a layer. It is a preparsed list of packages and files that are present in the SBOM for downstream consumption. There is an option to set the ability to push this summary.