### PR TITLE
Add SPDX parsing fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,7 @@ $ obom show -f ./examples/SPDXJSONExample-v2.3.spdx.json
 Document Name:         SPDX-Tools-v2.0
 DataLicense:           CC0-1.0
 Document Namespace:    http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301
-SPDX Version:          SPDX-2.3 # NOTE This is the default version for all spdx you have to comment out line 76 
-                                # from go\pkg\mod\github.com\spdx\tools-golang@v0.5.0\spdx\v2\v2_3\document.go
-                                # in order to pull the correct version from the actual SPDX JSON
+SPDX Version:          SPDX-2.3 
 Creation Date:         2010-01-29T18:30:22Z
 Creators:              LicenseFind-1.0
                        ExampleCodeInspect ()

--- a/cmd/files.go
+++ b/cmd/files.go
@@ -22,7 +22,7 @@ func filesCmd() *cobra.Command {
 Example:
 	obom files -f ./examples/SPDXJSONExample-v2.3.spdx.json`,
 		Run: func(cmd *cobra.Command, args []string) {
-			sbom, _, _, err := obom.LoadSBOMFromFile(opts.filename)
+			sbom, _, _, err := obom.LoadSBOMFromFile(opts.filename, true)
 			if err != nil {
 				fmt.Println("Error loading SBOM:", err)
 				os.Exit(1)

--- a/cmd/files.go
+++ b/cmd/files.go
@@ -28,7 +28,7 @@ Example:
 				os.Exit(1)
 			}
 
-			files, err := obom.GetFiles(sbom)
+			files, err := obom.GetFiles(sbom.Document)
 			if err != nil {
 				fmt.Println("Error getting files:", err)
 				os.Exit(1)

--- a/cmd/packages.go
+++ b/cmd/packages.go
@@ -25,7 +25,7 @@ func packagesCmd() *cobra.Command {
 				os.Exit(1)
 			}
 
-			packages, err := obom.GetPackages(sbom)
+			packages, err := obom.GetPackages(sbom.Document)
 			if err != nil {
 				fmt.Println("Error getting packages:", err)
 				os.Exit(1)

--- a/cmd/packages.go
+++ b/cmd/packages.go
@@ -19,7 +19,7 @@ func packagesCmd() *cobra.Command {
 		Short: "List packages the SBOM",
 		Long:  `List packages the SBOM that have external refs`,
 		Run: func(cmd *cobra.Command, args []string) {
-			sbom, _, _, err := obom.LoadSBOMFromFile(opts.filename)
+			sbom, _, _, err := obom.LoadSBOMFromFile(opts.filename, true)
 			if err != nil {
 				fmt.Println("Error loading SBOM:", err)
 				os.Exit(1)

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -21,6 +21,7 @@ type pushOpts struct {
 	reference           string
 	username            string
 	password            string
+	strict              bool
 	pushSummary         bool
 	ManifestAnnotations []string
 	attachArtifacts     []string
@@ -78,7 +79,7 @@ Example - Push an SPDX SBOM to a registry with attached artifacts where the key 
 				os.Exit(1)
 			}
 
-			sbom, desc, bytes, err := obom.LoadSBOMFromFile(opts.filename)
+			sbom, desc, bytes, err := obom.LoadSBOMFromFile(opts.filename, opts.strict)
 			if err != nil {
 				fmt.Println("Error loading SBOM:", err)
 				os.Exit(1)
@@ -128,6 +129,7 @@ Example - Push an SPDX SBOM to a registry with attached artifacts where the key 
 	pushCmd.Flags().StringVarP(&opts.username, "username", "u", "", "Username for the registry")
 	pushCmd.Flags().StringVarP(&opts.password, "password", "p", "", "Password for the registry")
 	pushCmd.Flags().BoolVarP(&opts.pushSummary, "pushSummary", "s", false, "Push summary blob to the registry")
+	pushCmd.Flags().BoolVarP(&opts.strict, "strict", "r", true, "Enable strict SPDX parsing as per the SPDX specification. Set --strict=false to fallback to simple JSON parsing strategy")
 	pushCmd.Flags().StringArrayVarP(&opts.attachArtifacts, "attach", "t", nil, "Attach artifacts to the SBOM")
 
 	// Add positional argument called reference to pushCmd

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -111,7 +111,7 @@ Example - Push an SPDX SBOM to a registry with attached artifacts where the key 
 			}
 
 			fmt.Printf("Pushing SBOM to %s@%s...\n", opts.reference, desc.Digest)
-			subject, err := obom.PushSBOM(sbom, desc, bytes, opts.reference, annotations, opts.pushSummary, attachArtifacts, repo)
+			subject, err := obom.PushSBOM(sbom.Document, desc, bytes, opts.reference, annotations, opts.pushSummary, attachArtifacts, repo)
 			if err != nil {
 				fmt.Println("Error pushing SBOM:", err)
 				os.Exit(1)

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -21,7 +21,7 @@ type pushOpts struct {
 	reference           string
 	username            string
 	password            string
-	strict              bool
+	disableStrict       bool
 	pushSummary         bool
 	ManifestAnnotations []string
 	attachArtifacts     []string
@@ -43,6 +43,12 @@ func pushCmd() *cobra.Command {
 
 Example - Push an SPDX SBOM to a registry
 	obom push -f spdx.json localhost:5000/spdx:latest 
+
+Example - Push an SPDX SBOM to a registry with annotations
+	obom push -f spdx.json localhost:5000/spdx:latest --annotation key1=value1 --annotation key2=value2
+
+Example - Push an SPDX SBOM to a registry with strict SPDX parsing disabled
+	obom push -f spdx.json localhost:5000/spdx:latest --disable-strict
 
 Example - Push an SPDX SBOM to a registry with annotations
 	obom push -f spdx.json localhost:5000/spdx:latest --annotation key1=value1 --annotation key2=value2
@@ -79,7 +85,9 @@ Example - Push an SPDX SBOM to a registry with attached artifacts where the key 
 				os.Exit(1)
 			}
 
-			sbom, desc, bytes, err := obom.LoadSBOMFromFile(opts.filename, opts.strict)
+			// set the strict mode to the opposite of the disableStrict flag
+			strict := !opts.disableStrict
+			sbom, desc, bytes, err := obom.LoadSBOMFromFile(opts.filename, strict)
 			if err != nil {
 				fmt.Println("Error loading SBOM:", err)
 				os.Exit(1)
@@ -129,7 +137,7 @@ Example - Push an SPDX SBOM to a registry with attached artifacts where the key 
 	pushCmd.Flags().StringVarP(&opts.username, "username", "u", "", "Username for the registry")
 	pushCmd.Flags().StringVarP(&opts.password, "password", "p", "", "Password for the registry")
 	pushCmd.Flags().BoolVarP(&opts.pushSummary, "pushSummary", "s", false, "Push summary blob to the registry")
-	pushCmd.Flags().BoolVarP(&opts.strict, "strict", "r", true, "Enable strict SPDX parsing as per the SPDX specification. Set --strict=false to fallback to simple JSON parsing strategy")
+	pushCmd.Flags().BoolVarP(&opts.disableStrict, "disable-strict", "r", false, "Disable strict SPDX parsing as per the SPDX specification. When disabled, obom will fall back to a simple JSON parsing strategy")
 	pushCmd.Flags().StringArrayVarP(&opts.attachArtifacts, "attach", "t", nil, "Attach artifacts to the SBOM")
 
 	// Add positional argument called reference to pushCmd

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -11,6 +11,7 @@ import (
 
 type showOptions struct {
 	filename string
+	strict   bool
 }
 
 func showCmd() *cobra.Command {
@@ -20,7 +21,7 @@ func showCmd() *cobra.Command {
 		Short: "Show summay of the spdx",
 		Long:  `Show the SPDX summary fields`,
 		Run: func(cmd *cobra.Command, args []string) {
-			sbom, desc, _, err := obom.LoadSBOMFromFile(opts.filename)
+			sbom, desc, _, err := obom.LoadSBOMFromFile(opts.filename, opts.strict)
 			if err != nil {
 				fmt.Println("Error loading SBOM:", err)
 				os.Exit(1)
@@ -32,6 +33,8 @@ func showCmd() *cobra.Command {
 
 	showCmd.Flags().StringVarP(&opts.filename, "file", "f", "", "Path to the SPDX SBOM file")
 	showCmd.MarkFlagRequired("file")
+
+	showCmd.Flags().BoolVarP(&opts.strict, "strict", "r", true, "Enable strict SPDX parsing as per the SPDX specification. Set --strict=false to fallback to simple JSON parsing strategy")
 
 	return showCmd
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/Azure/obom
 go 1.23
 
 require (
-	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0
 	github.com/package-url/packageurl-go v0.1.3
 	github.com/spdx/tools-golang v0.5.5
@@ -19,6 +18,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/sagikazarmark/locafero v0.6.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect

--- a/internal/print/print.go
+++ b/internal/print/print.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	obom "github.com/Azure/obom/pkg"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/spdx/tools-golang/spdx/v2/v2_3"
 )
@@ -23,11 +24,12 @@ func PrintCreatorInfo(doc *v2_3.Document) {
 }
 
 // PrintSBOMSummary returns the SPDX summary from the SBOM
-func PrintSBOMSummary(doc *v2_3.Document, desc *ocispec.Descriptor) {
+func PrintSBOMSummary(sbomDoc *obom.SPDXDocument, desc *ocispec.Descriptor) {
+	doc := sbomDoc.Document
 	fmt.Println(strings.Repeat("=", 80))
 	fmt.Printf("Document Name:         %s\n", doc.DocumentName)
 	fmt.Printf("Document Namespace:    %s\n", doc.DocumentNamespace)
-	fmt.Printf("SPDX Version:          %s\n", doc.SPDXVersion)
+	fmt.Printf("SPDX Version:          %s\n", sbomDoc.SPDXVersion)
 	fmt.Printf("Creation Date:         %s\n", doc.CreationInfo.Created)
 	PrintCreatorInfo(doc)
 	fmt.Printf("Packages:              %d\n", len(doc.Packages))

--- a/internal/print/print.go
+++ b/internal/print/print.go
@@ -29,11 +29,17 @@ func PrintSBOMSummary(sbomDoc *obom.SPDXDocument, desc *ocispec.Descriptor) {
 	fmt.Println(strings.Repeat("=", 80))
 	fmt.Printf("Document Name:         %s\n", doc.DocumentName)
 	fmt.Printf("Document Namespace:    %s\n", doc.DocumentNamespace)
-	fmt.Printf("SPDX Version:          %s\n", sbomDoc.SPDXVersion)
-	fmt.Printf("Creation Date:         %s\n", doc.CreationInfo.Created)
-	PrintCreatorInfo(doc)
-	fmt.Printf("Packages:              %d\n", len(doc.Packages))
-	fmt.Printf("Files:                 %d\n", len(doc.Files))
+	fmt.Printf("SPDX Version:          %s\n", sbomDoc.Version)
+	if doc.CreationInfo != nil {
+		fmt.Printf("Creation Date:         %s\n", doc.CreationInfo.Created)
+		PrintCreatorInfo(doc)
+	}
+	if doc.Packages != nil {
+		fmt.Printf("Packages:              %d\n", len(doc.Packages))
+	}
+	if doc.Files != nil {
+		fmt.Printf("Files:                 %d\n", len(doc.Files))
+	}
 	fmt.Printf("Digest:                %s\n", desc.Digest)
 	fmt.Println(strings.Repeat("=", 80))
 }

--- a/pkg/oci_test.go
+++ b/pkg/oci_test.go
@@ -30,7 +30,7 @@ func TestPushSBOM_Success_NoAttachArtifacts(t *testing.T) {
 	reader := io.NopCloser(strings.NewReader(spdx))
 
 	// Load the SPDX document from the reader
-	doc, desc, sbomBytes, err := LoadSBOMFromReader(reader)
+	doc, desc, sbomBytes, err := LoadSBOMFromReader(reader, true)
 
 	// Check that there was no error
 	if err != nil {
@@ -43,7 +43,7 @@ func TestPushSBOM_Success_NoAttachArtifacts(t *testing.T) {
 	}
 
 	// Call the PushSBOM function
-	sbomDesc, err := PushSBOM(doc, desc, sbomBytes, "localhost:5000/spdx:latest", annotations, false, nil, memDest)
+	sbomDesc, err := PushSBOM(doc.Document, desc, sbomBytes, "localhost:5000/spdx:latest", annotations, false, nil, memDest)
 	if err != nil {
 		t.Fatalf("expected no error from PushSBOM, got: %v", err)
 	}
@@ -112,7 +112,7 @@ func TestPushSBOM_Success_WithAttachArtifacts(t *testing.T) {
 	reader := io.NopCloser(strings.NewReader(spdx))
 
 	// Load the SPDX document from the reader
-	doc, desc, sbomBytes, err := LoadSBOMFromReader(reader)
+	doc, desc, sbomBytes, err := LoadSBOMFromReader(reader, true)
 
 	// Check that there was no error
 	if err != nil {
@@ -125,7 +125,7 @@ func TestPushSBOM_Success_WithAttachArtifacts(t *testing.T) {
 	}
 
 	// Call the PushSBOM function
-	sbomDesc, err := PushSBOM(doc, desc, sbomBytes, "localhost:5000/spdx:latest", nil, false, attachArtifacts, memDest)
+	sbomDesc, err := PushSBOM(doc.Document, desc, sbomBytes, "localhost:5000/spdx:latest", nil, false, attachArtifacts, memDest)
 	if err != nil {
 		t.Fatalf("expected no error from PushSBOM, got: %v", err)
 	}

--- a/pkg/sbom_test.go
+++ b/pkg/sbom_test.go
@@ -19,6 +19,18 @@ const spdxStr string = `{
 			}
 	}`
 
+const nonCompliantSPDXStr string = `{
+			"SPDXID": "NonCompliant",
+			"spdxVersion": "SPDX-2.2",
+			"name" : "SPDX-Example",
+			"documentNamespace" : "SPDX-Namespace-Example",
+			"creationInfo": {
+					"created": "2020-07-23T18:30:22Z",
+					"creators": ["Tool: SPDX-Java-Tools-v2.1.20", "Organization: Source Auditor Inc."],
+					"licenseListVersion": "3.6"
+			}
+	}`
+
 func TestLoadSBOMFromReader(t *testing.T) {
 
 	// Calculate the size of the SPDX string in bytes
@@ -51,6 +63,36 @@ func TestLoadSBOMFromReader(t *testing.T) {
 	// Check if the byte arrays are equal
 	if !bytes.Equal(sbomBytes, expectedBytes) {
 		t.Errorf("expected sbomBytes to be %v, got: %v", expectedBytes, sbomBytes)
+	}
+}
+
+func TestLoadSBOMFromReader_NonCompliantSucceedsWhenStrictFalse(t *testing.T) {
+	// Create a test reader with the SPDX JSON data
+	reader := io.NopCloser(strings.NewReader(nonCompliantSPDXStr))
+
+	// Call the function with the test reader
+	sbomDoc, _, _, err := LoadSBOMFromReader(reader, false)
+
+	// Check that there was no error
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if sbomDoc.Version != "SPDX-2.2" {
+		t.Errorf("expected SPDXVersion to be 'SPDX-2.2', got: %v", sbomDoc.Version)
+	}
+}
+
+func TestLoadSBOMFromReader_NonCompliantFailsWhenStrictTrue(t *testing.T) {
+	// Create a test reader with the SPDX JSON data
+	reader := io.NopCloser(strings.NewReader(nonCompliantSPDXStr))
+
+	// Call the function with the test reader
+	_, _, _, err := LoadSBOMFromReader(reader, true)
+
+	// Check that there was no error
+	if err == nil {
+		t.Fatalf("expected error when parsing with strict, got no err")
 	}
 }
 

--- a/pkg/sbom_test.go
+++ b/pkg/sbom_test.go
@@ -7,12 +7,11 @@ import (
 	"testing"
 )
 
-func TestLoadSBOMFromReader(t *testing.T) {
-	// Create a test SPDX JSON string
-	spdx := `{
+const spdxStr string = `{
 			"SPDXID": "SPDXRef-DOCUMENT",
-			"spdxVersion": "SPDX-2.3",
+			"spdxVersion": "SPDX-2.2",
 			"name" : "SPDX-Example",
+			"documentNamespace" : "SPDX-Namespace-Example",
 			"creationInfo": {
 					"created": "2020-07-23T18:30:22Z",
 					"creators": ["Tool: SPDX-Java-Tools-v2.1.20", "Organization: Source Auditor Inc."],
@@ -20,21 +19,28 @@ func TestLoadSBOMFromReader(t *testing.T) {
 			}
 	}`
 
+func TestLoadSBOMFromReader(t *testing.T) {
+
 	// Calculate the size of the SPDX string in bytes
-	expectedBytes := []byte(spdx)
+	expectedBytes := []byte(spdxStr)
 	size := int64(len(expectedBytes))
 
 	// Create a test reader with the SPDX JSON data
-	reader := io.NopCloser(strings.NewReader(spdx))
+	reader := io.NopCloser(strings.NewReader(spdxStr))
 
 	// Call the function with the test reader
-	doc, desc, sbomBytes, err := LoadSBOMFromReader(reader)
+	sbomDoc, desc, sbomBytes, err := LoadSBOMFromReader(reader)
 
 	// Check that there was no error
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
 
+	if sbomDoc.SPDXVersion != "SPDX-2.2" {
+		t.Errorf("expected SPDXVersion to be 'SPDX-2.2', got: %v", sbomDoc.SPDXVersion)
+	}
+
+	doc := sbomDoc.Document
 	// Check that the returned doc and desc have the expected values
 	if doc.DocumentName != "SPDX-Example" {
 		t.Errorf("expected document name to be 'SPDX-Example', got: %v", doc.DocumentName)
@@ -54,13 +60,18 @@ func TestLoadSBOMFromFile(t *testing.T) {
 	size := int64(21342)
 
 	// Call the function with the test file path
-	doc, desc, _, err := LoadSBOMFromFile(filePath)
+	sbomDoc, desc, _, err := LoadSBOMFromFile(filePath)
 
 	// Check that there was no error
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
 
+	if sbomDoc.SPDXVersion != "SPDX-2.3" {
+		t.Errorf("expected SPDXVersion to be 'SPDX-2.3', got: %v", sbomDoc.SPDXVersion)
+	}
+
+	doc := sbomDoc.Document
 	// Check that the returned doc and desc have the expected values
 	if doc.DocumentName != "SPDX-Tools-v2.0" {
 		t.Errorf("expected document name to be 'SPDX-Tools-v2.0', got: %v", doc.DocumentName)
@@ -70,5 +81,47 @@ func TestLoadSBOMFromFile(t *testing.T) {
 	}
 	if desc.Digest.String() != "sha256:2de3741a7be1be5f5e54e837524f2ec627fedfb82307dc004ae03b195abc092f" {
 		t.Errorf("expected desc.Digest to be 'sha256:2de3741a7be1be5f5e54e837524f2ec627fedfb82307dc004ae03b195abc092f', got: %v", desc.Digest.String())
+	}
+}
+
+func TestGetAnnotations(t *testing.T) {
+	// Create a test reader with the SPDX JSON data
+	reader := io.NopCloser(strings.NewReader(spdxStr))
+
+	// Call the function with the test reader
+	sbomDoc, _, _, err := LoadSBOMFromReader(reader)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	// Call the function with the SPDX document
+	annotations, err := GetAnnotations(sbomDoc)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	// Check that the returned annotations have the expected values
+	if len(annotations) != 5 {
+		t.Errorf("expected 5 annotations, got: %v", len(annotations))
+	}
+
+	if annotations[OCI_ANNOTATION_DOCUMENT_NAME] != "SPDX-Example" {
+		t.Errorf("expected document name annotation to be 'SPDX-Example', got: %v", annotations[OCI_ANNOTATION_DOCUMENT_NAME])
+	}
+
+	if annotations[OCI_ANNOTATION_DOCUMENT_NAMESPACE] != "SPDX-Namespace-Example" {
+		t.Errorf("expected document name annotation to be 'SPDX-Example', got: %v", annotations[OCI_ANNOTATION_DOCUMENT_NAME])
+	}
+
+	if annotations[OCI_ANNOTATION_SPDX_VERSION] != "SPDX-2.2" {
+		t.Errorf("expected SPDX version annotation to be 'SPDX-2.2', got: %v", annotations[OCI_ANNOTATION_SPDX_VERSION])
+	}
+
+	if annotations[OCI_ANNOTATION_CREATION_DATE] != "2020-07-23T18:30:22Z" {
+		t.Errorf("expected creation date annotation to be '2020-07-23T18:30:22Z', got: %v", annotations[OCI_ANNOTATION_CREATION_DATE])
+	}
+
+	if annotations[OCI_ANNOTATION_CREATORS] != "Tool: SPDX-Java-Tools-v2.1.20, Organization: Source Auditor Inc." {
+		t.Errorf("expected creators annotation to be 'Tool: SPDX-Java-Tools-v2.1.20, Organization: Source Auditor Inc.', got: %v", annotations[OCI_ANNOTATION_CREATORS])
 	}
 }

--- a/pkg/sbom_test.go
+++ b/pkg/sbom_test.go
@@ -29,15 +29,15 @@ func TestLoadSBOMFromReader(t *testing.T) {
 	reader := io.NopCloser(strings.NewReader(spdxStr))
 
 	// Call the function with the test reader
-	sbomDoc, desc, sbomBytes, err := LoadSBOMFromReader(reader)
+	sbomDoc, desc, sbomBytes, err := LoadSBOMFromReader(reader, true)
 
 	// Check that there was no error
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
 
-	if sbomDoc.SPDXVersion != "SPDX-2.2" {
-		t.Errorf("expected SPDXVersion to be 'SPDX-2.2', got: %v", sbomDoc.SPDXVersion)
+	if sbomDoc.Version != "SPDX-2.2" {
+		t.Errorf("expected SPDXVersion to be 'SPDX-2.2', got: %v", sbomDoc.Version)
 	}
 
 	doc := sbomDoc.Document
@@ -60,15 +60,15 @@ func TestLoadSBOMFromFile(t *testing.T) {
 	size := int64(21342)
 
 	// Call the function with the test file path
-	sbomDoc, desc, _, err := LoadSBOMFromFile(filePath)
+	sbomDoc, desc, _, err := LoadSBOMFromFile(filePath, true)
 
 	// Check that there was no error
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
 
-	if sbomDoc.SPDXVersion != "SPDX-2.3" {
-		t.Errorf("expected SPDXVersion to be 'SPDX-2.3', got: %v", sbomDoc.SPDXVersion)
+	if sbomDoc.Version != "SPDX-2.3" {
+		t.Errorf("expected SPDXVersion to be 'SPDX-2.3', got: %v", sbomDoc.Version)
 	}
 
 	doc := sbomDoc.Document
@@ -89,7 +89,7 @@ func TestGetAnnotations(t *testing.T) {
 	reader := io.NopCloser(strings.NewReader(spdxStr))
 
 	// Call the function with the test reader
-	sbomDoc, _, _, err := LoadSBOMFromReader(reader)
+	sbomDoc, _, _, err := LoadSBOMFromReader(reader, true)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}


### PR DESCRIPTION
## Summary

Add `--disable-strict` to `obom push` to allow SPDX SBOMs that don't fully comply with the SPDX spec to be pushed. When `--disable-strict` is used, the SPDX JSON is parsed as a JSON object. It will take a subset of the fields that are normally parsed out such as `spdxVersion`, `documentNamespace`, and `name` and add them as OCI annotations.

When `--disable-strict` is set, we will see the following output:
```
Warning: error parsing SPDX document: failed to parse SPDX identifier 'Bad Identifier'. Falling back to simple JSON parsing.
```

## SPDX Version
Additionally, this PR closes #16 as we now create a wrapper around the `tools-golang/spdx/v2/v2_3` model that stores the SPDX document model alongside the `Version` that we now directly parse out ourselves. Previously, we were relying on the `tools-golang` library to parse the model and we used the version set. But it turns out that the version set will always be that particular model's version, regardless of the version present in the actual SPDX. This poses an issue since we may get either SPDX 2.2 or SPDX 2.3 SBOMs. @lumjjb, one of the maintainers of `tools-golang/spdx` informed me that the models are supposed to be backwards compatible so we should be able to use a 2.3 model with a 2.2 SBOM. For now, the wrapper will exist until a better mechanism of determining the SPDX model and using some "generic" interface can be implemented upstream