### PR TITLE
Enhance artifact loading functions to support artifact name annotations on the layer matching ORAS functionality.

### DIFF
--- a/pkg/artifact.go
+++ b/pkg/artifact.go
@@ -15,10 +15,10 @@ func LoadArtifactFromFile(filename string, mediaType string) (*ocispec.Descripto
 		return nil, nil, fmt.Errorf("error loading artifact from file: %w", err)
 	}
 
-	return LoadArtifactFromReader(file, mediaType)
+	return LoadArtifactFromReader(file, mediaType, filename)
 }
 
-func LoadArtifactFromReader(reader io.ReadCloser, mediaType string) (*ocispec.Descriptor, []byte, error) {
+func LoadArtifactFromReader(reader io.ReadCloser, mediaType string, name string) (*ocispec.Descriptor, []byte, error) {
 	defer reader.Close()
 
 	// Read all the bytes from the reader into a slice
@@ -28,6 +28,14 @@ func LoadArtifactFromReader(reader io.ReadCloser, mediaType string) (*ocispec.De
 	}
 
 	desc := content.NewDescriptorFromBytes(mediaType, artifactBytes)
+
+	// Add artifact name annotation if name is provided and not empty
+	if name != "" {
+		if desc.Annotations == nil {
+			desc.Annotations = make(map[string]string)
+		}
+		desc.Annotations[ocispec.AnnotationTitle] = name
+	}
 
 	return &desc, artifactBytes, nil
 }

--- a/pkg/artifact_test.go
+++ b/pkg/artifact_test.go
@@ -3,6 +3,8 @@ package obom
 import (
 	"bytes"
 	"io"
+	"os"
+	"strings"
 	"testing"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -44,7 +46,7 @@ func TestLoadArtifactFromReader(t *testing.T) {
 	reader := io.NopCloser(bytes.NewReader(testData))
 
 	// Call the function with the test reader and media type
-	desc, _, err := LoadArtifactFromReader(reader, mediaType, "")
+	desc, _, err := LoadArtifactFromReader(reader, mediaType)
 
 	// Check that there was no error
 	if err != nil {
@@ -63,24 +65,24 @@ func TestLoadArtifactFromReader(t *testing.T) {
 	}
 }
 
-func TestLoadArtifactFromReader_WithName(t *testing.T) {
+func TestLoadArtifactFromReader_WithFilename(t *testing.T) {
 	// Define the test data and its size
 	testData := []byte(`{"test": "data"}`)
 	mediaType := "application/json"
-	artifactName := "test-artifact.json"
+	artifactFilename := "test-artifact.json"
 
 	// Create a test reader with the test data
 	reader := io.NopCloser(bytes.NewReader(testData))
 
-	// Call the function with the test reader, media type, and name
-	desc, _, err := LoadArtifactFromReader(reader, mediaType, artifactName)
+	// Call the function with the test reader, media type, and filename
+	desc, _, err := LoadArtifactFromReader(reader, mediaType, artifactFilename)
 
 	// Check that there was no error
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
 
-	// Check that the artifact name annotation is set
+	// Check that the artifact filename annotation is set
 	if desc.Annotations == nil {
 		t.Fatalf("expected annotations to be set, got nil")
 	}
@@ -89,12 +91,12 @@ func TestLoadArtifactFromReader_WithName(t *testing.T) {
 	if !exists {
 		t.Errorf("expected annotation %s to exist", ocispec.AnnotationTitle)
 	}
-	if title != artifactName {
-		t.Errorf("expected annotation %s to be '%s', got: %s", ocispec.AnnotationTitle, artifactName, title)
+	if title != artifactFilename {
+		t.Errorf("expected annotation %s to be '%s', got: %s", ocispec.AnnotationTitle, artifactFilename, title)
 	}
 }
 
-func TestLoadArtifactFromReader_WithoutName(t *testing.T) {
+func TestLoadArtifactFromReader_WithoutFilename(t *testing.T) {
 	// Define the test data and its size
 	testData := []byte(`{"test": "data"}`)
 	mediaType := "application/json"
@@ -102,18 +104,202 @@ func TestLoadArtifactFromReader_WithoutName(t *testing.T) {
 	// Create a test reader with the test data
 	reader := io.NopCloser(bytes.NewReader(testData))
 
-	// Call the function with the test reader and media type, but no name
-	desc, _, err := LoadArtifactFromReader(reader, mediaType, "")
+	// Call the function with the test reader and media type, but no filename
+	desc, _, err := LoadArtifactFromReader(reader, mediaType)
 
 	// Check that there was no error
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
 
-	// Check that no annotations are set when name is empty
+	// Check that no annotations are set when filename is empty
 	if desc.Annotations != nil {
 		if _, exists := desc.Annotations[ocispec.AnnotationTitle]; exists {
-			t.Errorf("expected no %s annotation when name is empty, but it was set", ocispec.AnnotationTitle)
+			t.Errorf("expected no %s annotation when filename is empty, but it was set", ocispec.AnnotationTitle)
 		}
+	}
+}
+
+func TestLoadArtifactFromReader_BackwardCompatibility(t *testing.T) {
+	// Test that calling without the filename parameter still works (backward compatibility)
+	testData := []byte(`{"test": "data"}`)
+	mediaType := "application/json"
+
+	// Create a test reader with the test data
+	reader := io.NopCloser(bytes.NewReader(testData))
+
+	// Call the function with just the required parameters (old way)
+	desc, _, err := LoadArtifactFromReader(reader, mediaType)
+
+	// Check that there was no error
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	// Check that no annotations are set when filename is not provided
+	if desc.Annotations != nil {
+		if _, exists := desc.Annotations[ocispec.AnnotationTitle]; exists {
+			t.Errorf("expected no %s annotation when filename is not provided, but it was set", ocispec.AnnotationTitle)
+		}
+	}
+}
+
+func TestLoadSBOMFromReader_BackwardCompatibility(t *testing.T) {
+	// Test that calling without the filename parameter still works (backward compatibility)
+	spdxStr := `{
+		"SPDXID": "SPDXRef-DOCUMENT",
+		"spdxVersion": "SPDX-2.2",
+		"name" : "SPDX-Example",
+		"documentNamespace" : "SPDX-Namespace-Example",
+		"creationInfo": {
+			"created": "2020-07-23T18:30:22Z",
+			"creators": ["Tool: SPDX-Java-Tools-v2.1.20"]
+		}
+	}`
+
+	// Create a test reader with the SPDX JSON data
+	reader := io.NopCloser(strings.NewReader(spdxStr))
+
+	// Call the function with just the required parameters (old way)
+	sbomDoc, desc, _, err := LoadSBOMFromReader(reader, true)
+
+	// Check that there was no error
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	// Check that the SBOM document was loaded correctly
+	if sbomDoc.Version != "SPDX-2.2" {
+		t.Errorf("expected SPDXVersion to be 'SPDX-2.2', got: %v", sbomDoc.Version)
+	}
+
+	// Check that no filename annotation is set when filename is not provided
+	if desc.Annotations != nil {
+		if _, exists := desc.Annotations[ocispec.AnnotationTitle]; exists {
+			t.Errorf("expected no %s annotation when filename is not provided, but it was set", ocispec.AnnotationTitle)
+		}
+	}
+}
+
+func TestLoadSBOMFromReader_WithOptionalFilename(t *testing.T) {
+	// Test that calling with the optional filename parameter works
+	spdxStr := `{
+		"SPDXID": "SPDXRef-DOCUMENT",
+		"spdxVersion": "SPDX-2.2",
+		"name" : "SPDX-Example",
+		"documentNamespace" : "SPDX-Namespace-Example",
+		"creationInfo": {
+			"created": "2020-07-23T18:30:22Z",
+			"creators": ["Tool: SPDX-Java-Tools-v2.1.20"]
+		}
+	}`
+
+	// Create a test reader with the SPDX JSON data
+	reader := io.NopCloser(strings.NewReader(spdxStr))
+	artifactFilename := "test-sbom.spdx.json"
+
+	// Call the function with the optional filename parameter
+	sbomDoc, desc, _, err := LoadSBOMFromReader(reader, true, artifactFilename)
+
+	// Check that there was no error
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	// Check that the SBOM document was loaded correctly
+	if sbomDoc.Version != "SPDX-2.2" {
+		t.Errorf("expected SPDXVersion to be 'SPDX-2.2', got: %v", sbomDoc.Version)
+	}
+
+	// Check that the artifact filename annotation is set
+	if desc.Annotations == nil {
+		t.Fatalf("expected annotations to be set, got nil")
+	}
+
+	title, exists := desc.Annotations[ocispec.AnnotationTitle]
+	if !exists {
+		t.Errorf("expected annotation %s to exist", ocispec.AnnotationTitle)
+	}
+	if title != artifactFilename {
+		t.Errorf("expected annotation %s to be '%s', got: %s", ocispec.AnnotationTitle, artifactFilename, title)
+	}
+}
+
+func TestLoadArtifactFromFile_ArtifactFilenameAnnotation(t *testing.T) {
+	// Define the path to the test file
+	filePath := "../examples/artifact.example.json"
+	mediaType := "application/json"
+	expectedFilename := "artifact.example.json" // Only the base filename, not the full path
+
+	// Call the function with the test file path and media type
+	desc, _, err := LoadArtifactFromFile(filePath, mediaType)
+
+	// Check that there was no error
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	// Check that the artifact filename annotation is set with just the filename
+	if desc.Annotations == nil {
+		t.Fatalf("expected annotations to be set, got nil")
+	}
+
+	title, exists := desc.Annotations[ocispec.AnnotationTitle]
+	if !exists {
+		t.Errorf("expected annotation %s to exist", ocispec.AnnotationTitle)
+	}
+	if title != expectedFilename {
+		t.Errorf("expected annotation %s to be '%s', got: %s", ocispec.AnnotationTitle, expectedFilename, title)
+	}
+}
+
+func TestLoadArtifactFromFile_FilenameExtractionFromPath(t *testing.T) {
+	// Test that filename is correctly extracted from various path formats
+	testCases := []struct {
+		name         string
+		filePath     string
+		expectedName string
+	}{
+		{
+			name:         "relative path with slash",
+			filePath:     "../examples/artifact.example.json",
+			expectedName: "artifact.example.json",
+		},
+		{
+			name:         "simple filename",
+			filePath:     "artifact.example.json",
+			expectedName: "artifact.example.json",
+		},
+	}
+
+	mediaType := "application/json"
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Skip if file doesn't exist (we're testing the filename extraction logic)
+			if _, err := os.Stat(tc.filePath); os.IsNotExist(err) {
+				t.Skipf("Test file %s does not exist", tc.filePath)
+			}
+
+			desc, _, err := LoadArtifactFromFile(tc.filePath, mediaType)
+
+			// Check that there was no error
+			if err != nil {
+				t.Fatalf("expected no error for path '%s', got: %v", tc.filePath, err)
+			}
+
+			// Check that only the filename (not the path) is in the annotation
+			if desc.Annotations == nil {
+				t.Fatalf("expected annotations to be set for path '%s', got nil", tc.filePath)
+			}
+
+			title, exists := desc.Annotations[ocispec.AnnotationTitle]
+			if !exists {
+				t.Errorf("expected annotation %s to exist for path '%s'", ocispec.AnnotationTitle, tc.filePath)
+			}
+			if title != tc.expectedName {
+				t.Errorf("for path '%s', expected annotation %s to be '%s', got: %s", tc.filePath, ocispec.AnnotationTitle, tc.expectedName, title)
+			}
+		})
 	}
 }

--- a/pkg/oci_test.go
+++ b/pkg/oci_test.go
@@ -30,7 +30,7 @@ func TestPushSBOM_Success_NoAttachArtifacts(t *testing.T) {
 	reader := io.NopCloser(strings.NewReader(spdx))
 
 	// Load the SPDX document from the reader
-	doc, desc, sbomBytes, err := LoadSBOMFromReader(reader, true, "")
+	doc, desc, sbomBytes, err := LoadSBOMFromReader(reader, true)
 
 	// Check that there was no error
 	if err != nil {
@@ -112,7 +112,7 @@ func TestPushSBOM_Success_WithAttachArtifacts(t *testing.T) {
 	reader := io.NopCloser(strings.NewReader(spdx))
 
 	// Load the SPDX document from the reader
-	doc, desc, sbomBytes, err := LoadSBOMFromReader(reader, true, "")
+	doc, desc, sbomBytes, err := LoadSBOMFromReader(reader, true)
 
 	// Check that there was no error
 	if err != nil {

--- a/pkg/oci_test.go
+++ b/pkg/oci_test.go
@@ -30,7 +30,7 @@ func TestPushSBOM_Success_NoAttachArtifacts(t *testing.T) {
 	reader := io.NopCloser(strings.NewReader(spdx))
 
 	// Load the SPDX document from the reader
-	doc, desc, sbomBytes, err := LoadSBOMFromReader(reader, true)
+	doc, desc, sbomBytes, err := LoadSBOMFromReader(reader, true, "")
 
 	// Check that there was no error
 	if err != nil {
@@ -112,7 +112,7 @@ func TestPushSBOM_Success_WithAttachArtifacts(t *testing.T) {
 	reader := io.NopCloser(strings.NewReader(spdx))
 
 	// Load the SPDX document from the reader
-	doc, desc, sbomBytes, err := LoadSBOMFromReader(reader, true)
+	doc, desc, sbomBytes, err := LoadSBOMFromReader(reader, true, "")
 
 	// Check that there was no error
 	if err != nil {

--- a/pkg/sbom.go
+++ b/pkg/sbom.go
@@ -40,16 +40,16 @@ func LoadSBOMFromFile(filename string, strict bool) (*SPDXDocument, *ocispec.Des
 	}
 	defer file.Close()
 
-	return LoadSBOMFromReader(file, strict)
+	return LoadSBOMFromReader(file, strict, filename)
 }
 
 // LoadSBOMFromReader reads an SPDX document from an io.ReadCloser, generates an OCI descriptor for the document,
 // and returns the loaded SPDX document and the OCI descriptor.
 // If an error occurs during reading the document or generating the descriptor, the error will be returned.
-func LoadSBOMFromReader(reader io.ReadCloser, strict bool) (*SPDXDocument, *ocispec.Descriptor, []byte, error) {
+func LoadSBOMFromReader(reader io.ReadCloser, strict bool, name string) (*SPDXDocument, *ocispec.Descriptor, []byte, error) {
 	defer reader.Close()
 
-	desc, sbomBytes, err := LoadArtifactFromReader(reader, MEDIATYPE_SPDX)
+	desc, sbomBytes, err := LoadArtifactFromReader(reader, MEDIATYPE_SPDX, name)
 	if err != nil {
 		return nil, nil, nil, err
 	}


### PR DESCRIPTION
Comparing artifacts uploaded to ACR using ORAS and OBOM has shown a discrepancy in that ORAS properly sets the filename annotation on the layer, while OBOM does not.  This causes issues when attempting to differentiate between different types of SPDX content files or SBOMs based on naming conventions etc.

This PR bring parity between ORAS and OBOM in a backwards compatible way, but default new artifacts get created with the title annotation on the layer properly added.